### PR TITLE
feat: add install target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ all: build
 # Environment Variables
 BUILD_DIR ?= build/  ## Directory for build files (pdf, artifacts)
 LATEX_FILE ?= resume.tex  ## Main LaTeX file
+TEXMFHOME := $(shell kpsewhich -var-value=TEXMFHOME)
+INSTALL_DIR := $(TEXMFHOME)/tex/luatex/local
 
 # Latexmk Configuration
 
@@ -32,6 +34,11 @@ preview: $(LATEX_FILE)  ## Builds the resume with preview and reload options
 .PHONY: clean
 clean:  ## Cleans up build files
 	latexmk -CA -outdir=$(BUILD_DIR) $(LATEX_FILE)
+
+.PHONY: install
+install:  ## Copies .cls to `TEXMFHOME`
+	@mkdir -p $(INSTALL_DIR)
+	cp resume.cls $(INSTALL_DIR)/resume.cls
 
 # ------------------------------------------------------------------------------
 # Help - Documentation

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ Here's an example of the output:
 
 ```bash
 git clone https://github.com/slyces/awesome-cv-timeline resume && cd resume
-cp -r examples/single-page private    # Copy the example
-cd private                            # Go in the folder
-make build                            # Build the example (using latexmk)
-open build/resume.pdf                 # Look at the output
+cp -r examples/multi-pages private        # Copy the example
+cd private                                # Go in the folder
+make build                                # Build the example (using latexmk)
+open build/resume.pdf                     # Look at the output
 ```
 
 > [!TIP]


### PR DESCRIPTION
Added install target to Makefile, after this you can use the document class anywhere locally. Also removes the need to keep copies of the class in the example directories.

Noticed there was no `single-page` example so replaced it with `multi-pages`.