### PR TITLE
2025-06-22 nodes misaligned after the switch to lualatex 1.18

### DIFF
--- a/resume.cls
+++ b/resume.cls
@@ -40,7 +40,7 @@
 % Needed to make header & footer effeciently
 \RequirePackage{fancyhdr}
 % Needed to manage colors
-\RequirePackage{xcolor}
+\RequirePackage{xcolor, luacolor}
 % Needed to use \ifxetex-\else-\fi statement
 \RequirePackage{ifxetex}
 % Needed to use \if-\then-\else statement


### PR DESCRIPTION
The time and text becomes misaligned for newer versions of lualatex that are included in Texlive 2024. Requiring luacolor in addition to xcolor fixes the issue.